### PR TITLE
Migrate/env service partition storage

### DIFF
--- a/docker-compose.application.yml
+++ b/docker-compose.application.yml
@@ -36,9 +36,9 @@ services:
       - ./jellyfin/${ENV_NAME}/config:/config
       - ./jellyfin/${ENV_NAME}/cache:/cache
       - ./jellyfin/${ENV_NAME}/tmp:/tmp/jellyfin
-      - /media/pi/Media/${ENV_NAME}/jellyfin/Music:/Music
-      - /media/pi/Media/${ENV_NAME}/jellyfin/Movies:/Movies
-      - /media/pi/Media/${ENV_NAME}/jellyfin/ChildrensMovies:/ChildrensMovies
+      - /media/pi/Data-0/${ENV_NAME}/jellyfin/Music:/Music
+      - /media/pi/Data-0/${ENV_NAME}/jellyfin/Movies:/Movies
+      - /media/pi/Data-0/${ENV_NAME}/jellyfin/ChildrensMovies:/ChildrensMovies
     restart: 'unless-stopped'
     networks:
       homelab_macvlan:


### PR DESCRIPTION
Add env prefix to data storage paths, in preparation for cluster storage. Switch disk too, for some reason the old one was ntfs formatted