### PR TITLE
expose DLNA ports for Jellyfin discovery and streaming

### DIFF
--- a/docker-swarm-stack.yml
+++ b/docker-swarm-stack.yml
@@ -86,6 +86,10 @@ services:
 
   jellyfin:
     image: jellyfin/jellyfin:${JELLYFIN_VERSION}
+    ports:
+      - "${JELLYFIN_HTTP_PORT}:8096"
+      - "${JELLYFIN_DLNA_PORT}:1900/udp"
+      - "${JELLYFIN_DISCOVERY_PORT}:7359/udp"
     volumes:
       - /var/cache/${ENV_NAME}/jellyfin:/cache
       - /srv/data/${ENV_NAME}/jellyfin/config:/config


### PR DESCRIPTION
Adds port mappings for Jellyfin DLNA functionality:
- Port 8096 for HTTP access
- Port 1900 for DLNA discovery (UDP)
- Port 7359 for DLNA streaming (UDP)

Uses existing environment variables to avoid port conflicts between environments.

🤖 Generated with [Claude Code](https://claude.ai/code)