### PR TITLE
Add Traefik TLS via deSEC DNS-01 for lan.barlows.cool

### DIFF
--- a/docker-swarm-stack.yml
+++ b/docker-swarm-stack.yml
@@ -9,10 +9,19 @@ secrets:
   release_manager_github_token:
     name: release_manager_github_token_${ENV_NAME}
     external: true
+  desec_token:
+    name: desec_token_${ENV_NAME}
+    external: true
 
 configs:
+  # pihole_custom_dns is unused (kept only because swarm configs are
+  # immutable and this file/config pointer predates the rename); remove
+  # it in a separate piece of work once pihole_custom_dns_v2 is confirmed
+  # working.
   pihole_custom_dns:
     file: ./pihole/${ENV_NAME}/etc/dnsmasq.d/02-custom-dns.conf
+  pihole_custom_dns_v2:
+    file: ./pihole/${ENV_NAME}/etc/dnsmasq.d/02-custom-dns-v2.conf
 
 services:
   pihole:
@@ -30,7 +39,7 @@ services:
     tmpfs:
       - /etc/pihole
     configs:
-      - source: pihole_custom_dns
+      - source: pihole_custom_dns_v2
         target: /etc/dnsmasq.d/02-custom-dns.conf
         mode: 0644
     secrets:
@@ -53,6 +62,10 @@ services:
         - "env=${ENV_NAME}"
         - "traefik.enable=true"
         - "traefik.http.routers.pihole-${ENV_NAME}.rule=Host(`pihole.${DOMAIN_SUFFIX}`)"
+        - "traefik.http.routers.pihole-${ENV_NAME}.tls=true"
+        - "traefik.http.routers.pihole-${ENV_NAME}.tls.certresolver=desec"
+        - "traefik.http.routers.pihole-${ENV_NAME}.tls.domains[0].main=${DOMAIN_SUFFIX}"
+        - "traefik.http.routers.pihole-${ENV_NAME}.tls.domains[0].sans=*.${DOMAIN_SUFFIX}"
         - "traefik.http.services.pihole-${ENV_NAME}.loadbalancer.server.port=80"
         - "traefik.http.middlewares.compression-pihole-${ENV_NAME}.compress=true"
         - "traefik.http.routers.pihole-${ENV_NAME}.middlewares=compression-pihole-${ENV_NAME}"
@@ -93,6 +106,10 @@ services:
         - "env=${ENV_NAME}"
         - "traefik.enable=true"
         - "traefik.http.routers.jellyfin-${ENV_NAME}.rule=Host(`jellyfin.${DOMAIN_SUFFIX}`)"
+        - "traefik.http.routers.jellyfin-${ENV_NAME}.tls=true"
+        - "traefik.http.routers.jellyfin-${ENV_NAME}.tls.certresolver=desec"
+        - "traefik.http.routers.jellyfin-${ENV_NAME}.tls.domains[0].main=${DOMAIN_SUFFIX}"
+        - "traefik.http.routers.jellyfin-${ENV_NAME}.tls.domains[0].sans=*.${DOMAIN_SUFFIX}"
         - "traefik.http.services.jellyfin-${ENV_NAME}.loadbalancer.server.port=8096"
         - "traefik.http.middlewares.compression-jellyfin-${ENV_NAME}.compress=true"
         - "traefik.http.middlewares.buffering-jellyfin-${ENV_NAME}.buffering.maxRequestBodyBytes=10000000"
@@ -120,15 +137,28 @@ services:
       - "--providers.swarm=true"
       - "--providers.swarm.exposedbydefault=false"
       - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
       - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.desec.acme.email=${ACME_EMAIL}"
+      - "--certificatesresolvers.desec.acme.storage=/letsencrypt/acme.json"
+      - "--certificatesresolvers.desec.acme.dnschallenge=true"
+      - "--certificatesresolvers.desec.acme.dnschallenge.provider=desec"
+      - "--certificatesresolvers.desec.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53"
       - "--log.level=INFO"
       - "--accesslog=true"
+    environment:
+      DESEC_TOKEN_FILE: '/run/secrets/desec_token'
+      LEGO_EXPERIMENTAL_CNAME_SUPPORT: 'true'
+    secrets:
+      - desec_token
     ports:
       - "${TRAEFIK_HTTP_PORT}:80"
       - "${TRAEFIK_HTTPS_PORT}:443"
       - "${TRAEFIK_DASHBOARD_PORT}:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /srv/data/${ENV_NAME}/traefik/letsencrypt:/letsencrypt
     networks:
       - homelab-shared
     deploy:
@@ -160,6 +190,10 @@ services:
         - "env=${ENV_NAME}"
         - "traefik.enable=true"
         - "traefik.http.routers.audiobookshelf-${ENV_NAME}.rule=Host(`audiobookshelf.${DOMAIN_SUFFIX}`)"
+        - "traefik.http.routers.audiobookshelf-${ENV_NAME}.tls=true"
+        - "traefik.http.routers.audiobookshelf-${ENV_NAME}.tls.certresolver=desec"
+        - "traefik.http.routers.audiobookshelf-${ENV_NAME}.tls.domains[0].main=${DOMAIN_SUFFIX}"
+        - "traefik.http.routers.audiobookshelf-${ENV_NAME}.tls.domains[0].sans=*.${DOMAIN_SUFFIX}"
         - "traefik.http.services.audiobookshelf-${ENV_NAME}.loadbalancer.server.port=80"
         - "traefik.http.middlewares.compression-audiobookshelf-${ENV_NAME}.compress=true"
         - "traefik.http.routers.audiobookshelf-${ENV_NAME}.middlewares=compression-audiobookshelf-${ENV_NAME}"
@@ -189,6 +223,10 @@ services:
         - "env=${ENV_NAME}"
         - "traefik.enable=true"
         - "traefik.http.routers.kavita-${ENV_NAME}.rule=Host(`kavita.${DOMAIN_SUFFIX}`)"
+        - "traefik.http.routers.kavita-${ENV_NAME}.tls=true"
+        - "traefik.http.routers.kavita-${ENV_NAME}.tls.certresolver=desec"
+        - "traefik.http.routers.kavita-${ENV_NAME}.tls.domains[0].main=${DOMAIN_SUFFIX}"
+        - "traefik.http.routers.kavita-${ENV_NAME}.tls.domains[0].sans=*.${DOMAIN_SUFFIX}"
         - "traefik.http.services.kavita-${ENV_NAME}.loadbalancer.server.port=5000"
         - "traefik.http.middlewares.compression-kavita-${ENV_NAME}.compress=true"
         - "traefik.http.routers.kavita-${ENV_NAME}.middlewares=compression-kavita-${ENV_NAME}"

--- a/docker-swarm-stack.yml
+++ b/docker-swarm-stack.yml
@@ -10,7 +10,7 @@ secrets:
     name: release_manager_github_token_${ENV_NAME}
     external: true
   desec_token:
-    name: desec_token_${ENV_NAME}
+    name: desec_token_${ENV_NAME}_v2
     external: true
 
 configs:

--- a/env/.env.preprod
+++ b/env/.env.preprod
@@ -1,5 +1,6 @@
-DOMAIN_SUFFIX=preprod.home
+DOMAIN_SUFFIX=preprod.lan.barlows.cool
 ENV_NAME=preprod
+ACME_EMAIL=oscarhbarlow+letsencrypt@pm.me
 
 AUDIOBOOKSHELF_VERSION=2.35.1
 AUDIOBOOKSHELF_REPLICAS=1

--- a/env/.env.prod
+++ b/env/.env.prod
@@ -1,5 +1,6 @@
-DOMAIN_SUFFIX=home
+DOMAIN_SUFFIX=lan.barlows.cool
 ENV_NAME=prod
+ACME_EMAIL=oscarhbarlow+letsencrypt@pm.me
 
 AUDIOBOOKSHELF_VERSION=2.35.1
 AUDIOBOOKSHELF_REPLICAS=1

--- a/pihole/preprod/etc/dnsmasq.d/02-custom-dns-v2.conf
+++ b/pihole/preprod/etc/dnsmasq.d/02-custom-dns-v2.conf
@@ -1,0 +1,14 @@
+local=/home/
+local=/preprod.home/
+local=/lan.barlows.cool/
+local=/preprod.lan.barlows.cool/
+
+bogus-priv
+
+# Production environment - all services route to Pi where Traefik runs
+address=/home/192.168.1.204
+address=/lan.barlows.cool/192.168.1.204
+
+# Preprod environment - all services route to N100 where Traefik runs
+address=/preprod.home/192.168.1.204
+address=/preprod.lan.barlows.cool/192.168.1.204

--- a/pihole/prod/etc/dnsmasq.d/02-custom-dns-v2.conf
+++ b/pihole/prod/etc/dnsmasq.d/02-custom-dns-v2.conf
@@ -1,0 +1,14 @@
+local=/home/
+local=/preprod.home/
+local=/lan.barlows.cool/
+local=/preprod.lan.barlows.cool/
+
+bogus-priv
+
+# Production environment - all services route to Pi where Traefik runs
+address=/home/192.168.1.204
+address=/lan.barlows.cool/192.168.1.204
+
+# Preprod environment - all services route to N100 where Traefik runs
+address=/preprod.home/192.168.1.204
+address=/preprod.lan.barlows.cool/192.168.1.204


### PR DESCRIPTION
## Summary
- Wildcard TLS cert for `*.lan.barlows.cool` via Let's Encrypt DNS-01, using deSEC as the DNS-01 provider (Hover has no DNS-01-capable API, so `_acme-challenge.lan.barlows.cool` is CNAME-delegated to a deSEC-hosted zone — confirmed live via `dig`).
- `DOMAIN_SUFFIX` moves from `home` / `preprod.home` to `lan.barlows.cool` / `preprod.lan.barlows.cool`; old `.home` entries are kept in pihole's dnsmasq config alongside the new ones for rollback safety.
- Traefik: added `web` → `websecure` redirect, `desec` cert resolver (DNS-01, explicit public resolvers so pihole doesn't shadow lego's propagation check, `LEGO_EXPERIMENTAL_CNAME_SUPPORT` so lego follows the CNAME to the deSEC zone the token actually owns), persistent `acme.json` volume, and the deSEC token wired in via `DESEC_TOKEN_FILE` from a Docker secret.
- Each service router now requests the wildcard cert (`tls.domains.main`/`sans`), declared redundantly per-router so it isn't dependent on any single service staying up.
- pihole's dnsmasq config is split into a new `pihole_custom_dns_v2` config object (swarm configs are immutable) — the old `pihole_custom_dns` config/file is left in place intentionally, to be removed in a follow-up once v2 is confirmed working in production.

## Not done / carried by the operator
This repo doesn't run cluster commands directly (see CLAUDE.md), so none of this has been deployed or had cert issuance verified — see the follow-up message for the manual steps (secret creation, preprod CNAME, deploy, cleanup).

## Test plan
- [ ] Create the `desec_token_prod` (and later `desec_token_preprod`) Docker secrets on the swarm
- [ ] `make env-up ENV=prod` and confirm Traefik logs show successful ACME issuance for `*.lan.barlows.cool`
- [ ] Confirm `pihole.lan.barlows.cool` etc. resolve on the LAN and load over HTTPS with a trusted cert
- [ ] Confirm old `.home` hostnames still resolve (pihole) as a rollback path
- [ ] Once stable, remove the orphaned `pihole_custom_dns` swarm config object

🤖 Generated with [Claude Code](https://claude.com/claude-code)